### PR TITLE
Fixes null ref issue on NotifyProperyChanged when using custom EagerLoad settings

### DIFF
--- a/CoordinateSharp/Coordinate.cs
+++ b/CoordinateSharp/Coordinate.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  (c) 2017, Justin Gielski
  CoordinateSharp is a .NET standard library that is intended to ease geographic coordinate 
  format conversions and location based celestial calculations.
@@ -645,12 +645,12 @@ namespace CoordinateSharp
             switch (propName)
             {
                 case "CelestialInfo":
-                    if (!EagerLoadSettings.Celestial) { return; }
-                    this.celestialInfo.CalculateCelestialTime(this.latitude.DecimalDegree, this.longitude.DecimalDegree, this.geoDate);
+                    if (celestialInfo == null || !EagerLoadSettings.Celestial) { return; }
+                    celestialInfo.CalculateCelestialTime(latitude.DecimalDegree, longitude.DecimalDegree, geoDate);
                     break;
                 case "UTM":
-                    if (!EagerLoadSettings.UTM_MGRS) { return; }
-                    this.utm.ToUTM(this.latitude.ToDouble(), this.longitude.ToDouble(), this.utm);
+                    if (utm == null || !EagerLoadSettings.UTM_MGRS) { return; }
+                    utm.ToUTM(latitude.ToDouble(), longitude.ToDouble(), utm);
                     break;
                 case "utm":
                     //Adjust case and notify of change. 
@@ -658,23 +658,23 @@ namespace CoordinateSharp
                     propName = "UTM";
                     break;
                 case "MGRS":
-                    if (!EagerLoadSettings.UTM_MGRS) { return; }
-                    this.MGRS.ToMGRS(this.utm);
+                    if (MGRS == null || !EagerLoadSettings.UTM_MGRS) { return; }
+                    MGRS.ToMGRS(utm);
                     break;
                 case "Cartesian":
-                    if (!EagerLoadSettings.Cartesian) { return; }
+                    if (Cartesian == null || !EagerLoadSettings.Cartesian) { return; }
                     Cartesian.ToCartesian(this);
                     break;
                 case "ECEF":
-                    if (!EagerLoadSettings.ECEF) { return; }
+                    if (ECEF == null || !EagerLoadSettings.ECEF) { return; }
                     ECEF.ToECEF(this);
                     break;
                 default:
                     break;
             }
-            if (this.PropertyChanged != null)
+            if (PropertyChanged != null)
             {                         
-                this.PropertyChanged(this, new PropertyChangedEventArgs(propName));
+                PropertyChanged(this, new PropertyChangedEventArgs(propName));
             }
         }
 


### PR DESCRIPTION
eagerLoad.Cartesian = false;
eagerLoad.Celestial = false;
eagerLoad.UTM_MGRS = false;
on a Coordinate then calling LoadUTM_MGRS_Info().
celestialInfo was throwing null, but I put in a null check for utm, MGRS, Cartesian and ECEF.

Also removed the unnecessary "this" usage in the method.

Here's the test case I used to reproduce the issue:
https://gist.github.com/Naphier/8d06bc327a661b00c0ef0e43f09e5c1e

I didn't feel it needed to be included in the commit because it really didn't follow the paradigm. If I get a chance I might write either a set of unit tests or get this in one of the sections of the TestProj.

Cheers and thanks for the hard work on this project. Saved me a lot of headache to convert from lat/lng to MGRS.

For future reference, how do I tell which branch you'd like work done in? I imagine that the Feature_Branch, NMEA, and ECEF are all feature branches. It's a little hard to tell which one you'd like work to be done in. Also, when I forked 1.1.3.9 was not existent, so I had to re-fork (just pulling in the branch was being a too big of a pain). Usually there's a "develop" branch that's just downstream of master. Will you be working in 1.1.3.9 for a while? 

If I have time I could do some cleanup and refactoring for you. But I don't want to do work then a new branch appears that you'd like commits to :wink:
