### PR TITLE
Improve UTM and MGRS performance

### DIFF
--- a/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
@@ -172,7 +172,7 @@ namespace CoordinateSharp
             if ((longz < 1 || longz > 60) && longz!=0 && systemType!= MGRS_Type.MGRS_Polar) { Debug.WriteLine("Longitudinal zone out of range", "UTM longitudinal zones must be between 1-60."); }
             if (!Verify_Lat_Zone(latz)) { throw new ArgumentException("Latitudinal zone invalid", "UTM latitudinal zone was unrecognized."); }
             if (n < 0 || n > 10000000) { throw new ArgumentOutOfRangeException("Northing out of range", "Northing must be between 0-10,000,000."); }
-            if (d.Count() < 2 || d.Count() > 2) { throw new ArgumentException("Digraph invalid", "MGRS Digraph was unrecognized."); }
+            if (d.Length < 2 || d.Length > 2) { throw new ArgumentException("Digraph invalid", "MGRS Digraph was unrecognized."); }
             if (ds.digraph1.Where(x => x.Letter == d.ToUpper()[0].ToString()).Count() == 0) { throw new ArgumentException("Digraph invalid", "MGRS Digraph was unrecognized."); }
             if (ds.digraph2.Where(x => x.Letter == d.ToUpper()[1].ToString()).Count() == 0) { throw new ArgumentException("Digraph invalid", "MGRS Digraph was unrecognized."); }
             latZone = latz.ToUpper();
@@ -187,7 +187,7 @@ namespace CoordinateSharp
 
         private bool Verify_Lat_Zone(string l)
         {
-            if (LatZones.longZongLetters.Where(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)).Count() != 1)
+            if (!LatZones.longZongLetters.Any(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }

--- a/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
@@ -109,7 +109,7 @@ namespace CoordinateSharp
             if(!int.TryParse(resultString, out longz))
             {
                 //Check Polar First
-                if (!Regex.Match(gridZone.ToUpper(), "[ABZY]").Success)
+                if (!ZonesRegex.UpsZoneRegex.IsMatch(gridZone))
                 {
                     throw new FormatException("The MGRS Grid Zone Designator format is invalid.");
                 }
@@ -141,7 +141,7 @@ namespace CoordinateSharp
             if (!int.TryParse(resultString, out longz))
             {
                 //Check Polar First
-                if (!Regex.Match(gridZone.ToUpper(), "[ABZY]").Success)
+                if (!ZonesRegex.UpsZoneRegex.IsMatch(gridZone) )
                 {
                     throw new FormatException("The MGRS Grid Zone Designator format is invalid.");
                 }
@@ -158,8 +158,7 @@ namespace CoordinateSharp
         /// </summary>
         private void Construct_MGRS(string latz, int longz, string d, double e, double n, double rad, double flt)
         {
-            Regex rg = new Regex("[aAbByYzZ]");
-            Match m = rg.Match(latz);
+            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
 
             if (m.Success)
             {
@@ -190,7 +189,7 @@ namespace CoordinateSharp
 
         private bool Verify_Lat_Zone(string l)
         {
-            if (LatZones.longZongLetters.Where(x => x == l.ToUpper()).Count() != 1)
+            if (LatZones.longZongLetters.Where(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)).Count() != 1)
             {
                 return false;
             }
@@ -203,8 +202,7 @@ namespace CoordinateSharp
         }
         internal void ToMGRS(UniversalTransverseMercator utm)
         {
-            Regex rg = new Regex("[ABYZ]");
-            Match m = rg.Match(utm.LatZone.ToUpper());
+            Match m = ZonesRegex.UpsZoneRegex.Match(utm.LatZone);
 
             string digraph1;
             string digraph2;
@@ -520,8 +518,7 @@ namespace CoordinateSharp
         public static double[] MGRStoSignedDegree(MilitaryGridReferenceSystem mgrs)
         {
 
-            Regex upsCheck = new Regex("[AaBbYyZz]");
-            if (upsCheck.IsMatch(mgrs.latZone))
+            if (ZonesRegex.UpsZoneRegex.IsMatch(mgrs.latZone))
             {
                 Coordinate c = MGRStoLatLong(mgrs);
                 return new double[] { c.Latitude.ToDouble(), c.Longitude.ToDouble() };

--- a/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/MGRS.Methods.cs
@@ -158,9 +158,7 @@ namespace CoordinateSharp
         /// </summary>
         private void Construct_MGRS(string latz, int longz, string d, double e, double n, double rad, double flt)
         {
-            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
-
-            if (m.Success)
+            if (ZonesRegex.UpsZoneRegex.IsMatch(latz))
             {
                 systemType = MGRS_Type.MGRS_Polar;
                 if (longz != 0)
@@ -202,14 +200,12 @@ namespace CoordinateSharp
         }
         internal void ToMGRS(UniversalTransverseMercator utm)
         {
-            Match m = ZonesRegex.UpsZoneRegex.Match(utm.LatZone);
-
             string digraph1;
             string digraph2;
 
             Digraphs digraphs;
 
-            if (m.Success)
+            if (ZonesRegex.UpsZoneRegex.IsMatch(utm.LatZone))
             {
                 systemType = MGRS_Type.MGRS_Polar;
                 digraphs = new Digraphs(systemType, utm.LatZone);

--- a/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
@@ -278,7 +278,7 @@ namespace CoordinateSharp
         /// <returns>boolean</returns>
         private bool Verify_Lat_Zone(string l)
         {
-            if (LatZones.longZongLetters.Where(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)).Count() != 1)
+            if (!LatZones.longZongLetters.Any(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }

--- a/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
@@ -105,8 +105,7 @@ namespace CoordinateSharp
             if (gridZone.Count() == 1)
             {
                 longz = 0;
-                Regex rg = new Regex("[aAbByYzZ]");
-                Match m = rg.Match(gridZone);
+                Match m = ZonesRegex.UpsZoneRegex.Match(gridZone);
                 if (m.Success) { latz = gridZone; }
                 else { throw new FormatException("The UTM Grid Zone Designator format is invalid."); }
             }
@@ -144,8 +143,7 @@ namespace CoordinateSharp
             if (gridZone.Count() == 1)
             {
                 longz = 0;
-                Regex rg = new Regex("[aAbByYzZ]");
-                Match m = rg.Match(gridZone);
+                Match m = ZonesRegex.UpsZoneRegex.Match(gridZone);
                 if (m.Success) { latz = gridZone; }
                 else { throw new FormatException("The UTM Grid Zone Designator format is invalid."); }
 
@@ -174,8 +172,7 @@ namespace CoordinateSharp
         /// </summary>
         private void Construct_UTM(string latz, int longz, double est, double nrt, double radius, double flaten, bool suppressWarnings)
         {
-            Regex rg = new Regex("[aAbByYzZ]");
-            Match m = rg.Match(latz);
+            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
 
             if (m.Success)
             {
@@ -251,8 +248,7 @@ namespace CoordinateSharp
         internal UniversalTransverseMercator(string latz, int longz, double e, double n, Coordinate c, double rad, double flt, bool suppressWarnings)
         {
             //validate utm
-            Regex rg = new Regex("[aAbByYzZ]");
-            Match m = rg.Match(latz);
+            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
 
             if (m.Success)
             {
@@ -286,7 +282,7 @@ namespace CoordinateSharp
         /// <returns>boolean</returns>
         private bool Verify_Lat_Zone(string l)
         {
-            if (LatZones.longZongLetters.Where(x => x == l.ToUpper()).Count() != 1)
+            if (LatZones.longZongLetters.Where(x => string.Equals(x, l, StringComparison.OrdinalIgnoreCase)).Count() != 1)
             {
                 return false;
             }
@@ -769,14 +765,12 @@ namespace CoordinateSharp
         {
 
             bool southhemi = false;
-            Regex upsCheck = new Regex("[AaBbYyZz]");
-            if(upsCheck.IsMatch(utm.latZone))
+            if(ZonesRegex.UpsZoneRegex.IsMatch(utm.latZone))
             {
                 return UPS.UPS_To_Geodetic(utm, eagerLoad);
             }
 
-            Regex regex = new Regex("[CcDdEeFfGgHhJjKkLlMm]");
-            if (regex.IsMatch(utm.latZone)) { southhemi = true; }
+            if (ZonesRegex.SouthEmisphereZone.IsMatch(utm.latZone)) { southhemi = true; }
 
             double cmeridian;
 
@@ -819,8 +813,7 @@ namespace CoordinateSharp
 
             bool southhemi = false;
 
-            Regex upsCheck = new Regex("[AaBbYyZz]");
-            if (upsCheck.IsMatch(utm.latZone))
+            if (ZonesRegex.UpsZoneRegex.IsMatch(utm.latZone))
             {
                 Coordinate c = UPS.UPS_To_Geodetic(utm, new EagerLoad(false));
                 return new double[] { c.Latitude.ToDouble(), c.Longitude.ToDouble() };

--- a/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
@@ -105,8 +105,7 @@ namespace CoordinateSharp
             if (gridZone.Count() == 1)
             {
                 longz = 0;
-                Match m = ZonesRegex.UpsZoneRegex.Match(gridZone);
-                if (m.Success) { latz = gridZone; }
+                if (ZonesRegex.UpsZoneRegex.IsMatch(gridZone)) { latz = gridZone; }
                 else { throw new FormatException("The UTM Grid Zone Designator format is invalid."); }
             }
             else //UTM
@@ -143,8 +142,7 @@ namespace CoordinateSharp
             if (gridZone.Count() == 1)
             {
                 longz = 0;
-                Match m = ZonesRegex.UpsZoneRegex.Match(gridZone);
-                if (m.Success) { latz = gridZone; }
+                if (ZonesRegex.UpsZoneRegex.IsMatch(gridZone)) { latz = gridZone; }
                 else { throw new FormatException("The UTM Grid Zone Designator format is invalid."); }
 
             }
@@ -172,9 +170,7 @@ namespace CoordinateSharp
         /// </summary>
         private void Construct_UTM(string latz, int longz, double est, double nrt, double radius, double flaten, bool suppressWarnings)
         {
-            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
-
-            if (m.Success)
+            if (ZonesRegex.UpsZoneRegex.IsMatch(latz))
             {
                 systemType = UTM_Type.UPS;
                 if (longz != 0)
@@ -248,9 +244,7 @@ namespace CoordinateSharp
         internal UniversalTransverseMercator(string latz, int longz, double e, double n, Coordinate c, double rad, double flt, bool suppressWarnings)
         {
             //validate utm
-            Match m = ZonesRegex.UpsZoneRegex.Match(latz);
-
-            if (m.Success)
+            if (ZonesRegex.UpsZoneRegex.IsMatch(latz))
             {
                 systemType = UTM_Type.UPS;
                 if (longz != 0)
@@ -770,7 +764,7 @@ namespace CoordinateSharp
                 return UPS.UPS_To_Geodetic(utm, eagerLoad);
             }
 
-            if (ZonesRegex.SouthEmisphereZone.IsMatch(utm.latZone)) { southhemi = true; }
+            if (ZonesRegex.SouthEmisphereZoneRegex.IsMatch(utm.latZone)) { southhemi = true; }
 
             double cmeridian;
 

--- a/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
+++ b/CoordinateSharp/UTM_MGRS/UTM.Methods.cs
@@ -102,7 +102,7 @@ namespace CoordinateSharp
             int longz;
             string latz;
             //DETERMINE IF UPS COORD
-            if (gridZone.Count() == 1)
+            if (gridZone.Length == 1)
             {
                 longz = 0;
                 if (ZonesRegex.UpsZoneRegex.IsMatch(gridZone)) { latz = gridZone; }
@@ -139,7 +139,7 @@ namespace CoordinateSharp
             int longz;
             string latz;
             //DETERMINE IF UPS COORD
-            if (gridZone.Count() == 1)
+            if (gridZone.Length == 1)
             {
                 longz = 0;
                 if (ZonesRegex.UpsZoneRegex.IsMatch(gridZone)) { latz = gridZone; }
@@ -180,7 +180,9 @@ namespace CoordinateSharp
             }
             else if (longz < 1 || longz > 60) { Warn(suppressWarnings, "Longitudinal zone out of range", "UTM longitudinal zones must be between 1-60."); }
 
+#if DEBUG // Warn does nothing in RELEASE mode, strip Verify_Lat_Zone call because it is very expensive 
             if (!Verify_Lat_Zone(latz)) {Warn(suppressWarnings, "Latitudinal zone invalid", "UTM latitudinal zone was unrecognized.");        }
+#endif
 
             if (systemType== UTM_Type.UTM && ( est < 160000 || est > 834000)) {  Warn(suppressWarnings, "The Easting value provided is outside the max allowable range. Use with caution.");  }
             if (systemType == UTM_Type.UPS && (est < 887000 || est > 3113000)) { Warn(suppressWarnings, "The Easting value provided is outside the max allowable range. Use with caution.");  }

--- a/CoordinateSharp/UTM_MGRS/ZonesRegex.cs
+++ b/CoordinateSharp/UTM_MGRS/ZonesRegex.cs
@@ -7,11 +7,11 @@ namespace CoordinateSharp
         /// <summary>
         /// [aAbByYzZ] / Also works for [AaBbYyZz] / [ABYZ]
         /// </summary>
-        internal static Regex UpsZoneRegex = new Regex("[aAbByYzZ]", RegexOptions.Compiled);
+        internal static Regex UpsZoneRegex = new Regex("[aAbByYzZ]");
 
         /// <summary>
         /// [CcDdEeFfGgHhJjKkLlMm]
         /// </summary>
-        internal static Regex SouthEmisphereZone = new Regex("[CcDdEeFfGgHhJjKkLlMm]", RegexOptions.Compiled);
+        internal static Regex SouthEmisphereZoneRegex = new Regex("[CcDdEeFfGgHhJjKkLlMm]");
     }
 }

--- a/CoordinateSharp/UTM_MGRS/ZonesRegex.cs
+++ b/CoordinateSharp/UTM_MGRS/ZonesRegex.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoordinateSharp
+{
+    internal static class ZonesRegex
+    {
+        /// <summary>
+        /// [aAbByYzZ] / Also works for [AaBbYyZz] / [ABYZ]
+        /// </summary>
+        internal static Regex UpsZoneRegex = new Regex("[aAbByYzZ]", RegexOptions.Compiled);
+
+        /// <summary>
+        /// [CcDdEeFfGgHhJjKkLlMm]
+        /// </summary>
+        internal static Regex SouthEmisphereZone = new Regex("[CcDdEeFfGgHhJjKkLlMm]", RegexOptions.Compiled);
+    }
+}


### PR DESCRIPTION
Hi,

I'm using CoordinateSharp for really massive coordinate conversion. My benchmark have shown that UTM / MGRS code regular expression is really "expensive" due to their parsing by the dotnet framework.

This pull-request store the regular expression in static fields, to avoid this cost.

I've also :
- optimized some string related processing to limit memory usage ;
- optimized some list lookup ;
- added a condition on a warning code that was very expensive and that add no effect in Release mode (as it calls `Debug.WriteLine` that is stripped by compiler when DEBUG is not defined)

Benchmark used :
```
var eagerNONE = new EagerLoad(false);
// Warmup
var utm = new UniversalTransverseMercator("T", 32, 336925, 5283644);
var coord = UniversalTransverseMercator.ConvertUTMtoLatLong(utm, eagerNONE);

var sw = Stopwatch.StartNew();
for (var i = 0; i < 100000; ++i)
{
    utm = new UniversalTransverseMercator("T", 32, 336925, 5283644);
    coord = UniversalTransverseMercator.ConvertUTMtoLatLong(utm, eagerNONE);
}
sw.Stop();
Console.Write(sw.ElapsedMilliseconds);
```

Results on .NET 6 on a i7-11700KF (3.6 GHz) :
- before optimization : 600 msec (0.006 per call)
- after optimization : 80 msec (0.0008 per call)

It's 13 times faster.

I've run existing tests, and everything seems fine.