### PR TITLE
2.24.1.1

### DIFF
--- a/CoordinateSharp.Magnetic/CoordinateSharp.Magnetic.csproj
+++ b/CoordinateSharp.Magnetic/CoordinateSharp.Magnetic.csproj
@@ -47,7 +47,7 @@ For more information, please contact Signature Group, LLC at this address: sales
     <TargetFrameworks>net40; netstandard1.3; netstandard1.4; netstandard2.0; netstandard2.1; net50; net60; net70; net80</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.13.0</Version>
+    <Version>1.1.14.0</Version>
     <Authors>Signature Group, LLC</Authors>
     <Company />
     <PackageProjectUrl>https://github.com/Tronald/CoordinateSharp</PackageProjectUrl>
@@ -61,7 +61,7 @@ For more information, please contact Signature Group, LLC at this address: sales
     <PackageIconUrl></PackageIconUrl>
     <PackageId>CoordinateSharp.Magnetic</PackageId>
     <Title>CoordinateSharp.Magnetic</Title>
-    <AssemblyVersion>1.1.13.0</AssemblyVersion>
+    <AssemblyVersion>1.1.14.0</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>true</SignAssembly>
     <PackageIcon>128x128.png</PackageIcon>

--- a/CoordinateSharp/Celestial/Celestial.StaticMethods.cs
+++ b/CoordinateSharp/Celestial/Celestial.StaticMethods.cs
@@ -1147,7 +1147,7 @@ namespace CoordinateSharp
             double lw = rad * -longi;
             double phi = rad * lat;
 
-            var events = SunCalc.Get_Event_Time(lw, phi, alt, date, offset, false);
+            var events = SunCalc.Get_Event_Time(lat, longi, lw, phi, alt, date, offset, false);
          
             var altE = new AltitudeEvents() { Rising = events[0], Setting = events[1] };
 

--- a/CoordinateSharp/CoordinateSharp.csproj
+++ b/CoordinateSharp/CoordinateSharp.csproj
@@ -50,26 +50,27 @@ Please visit http://coordinatesharp.com/licensing or contact Signature Group, LL
     <TargetFrameworks>net40; netstandard1.3; netstandard1.4; netstandard2.0; netstandard2.1; net50; net60; net70; net80</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.23.1.1</Version>
+    <Version>2.24.1.1</Version>
     <Authors>Signature Group, LLC</Authors>
     <Company />
     <PackageProjectUrl>https://github.com/Tronald/CoordinateSharp</PackageProjectUrl>
     <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>Copyright 2024</Copyright>
     <Description>CoordinateSharp is a high powered, lightweight .NET library that can convert geographical coordinates, perform distance logic, and calculate location based sun, moon, and magnetic information with minimal code.</Description>
-    <PackageReleaseNotes>-Adds the ability to densify polylines to mitigate geofence spherical distortions over long distances.</PackageReleaseNotes>
+    <PackageReleaseNotes>-Fixes bug causing incorrect sun condition to report in circumpolar regions during slow transition at horizon.
+-Adds feature to allow custom specification of earth shape during point densification.</PackageReleaseNotes>
     <PackageTags>Conversion; Latitude; Longitude; Coordinates; Geography; Sun; Moon; Solar; Lunar; Time; MGRS; UTM; EPSG:3857; ECEF; GEOREF; Web Mercator;</PackageTags>
     <!-- <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>-->
     <PackageLicenseFile>License.txt</PackageLicenseFile>    <PackageIconUrl></PackageIconUrl>
     <PackageId>CoordinateSharp</PackageId>
     <Title>CoordinateSharp</Title>
-    <AssemblyVersion>2.23.1.1</AssemblyVersion>
+    <AssemblyVersion>2.24.1.1</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>true</SignAssembly>
     <PackageIcon>128x128.png</PackageIcon>
     <AssemblyOriginatorKeyFile>CoordinateSharp Strong Name.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <FileVersion>2.23.1.1</FileVersion>
+    <FileVersion>2.24.1.1</FileVersion>
     <RepositoryUrl>https://github.com/Tronald/CoordinateSharp</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/CoordinateSharp_UnitTests/Celestial.Solar.cs
+++ b/CoordinateSharp_UnitTests/Celestial.Solar.cs
@@ -725,15 +725,58 @@ namespace CoordinateSharp_UnitTests
             Assert.AreEqual(new TimeSpan(24, 0, 0), c.CelestialInfo.DaySpan + c.CelestialInfo.NightSpan);
             Assert.AreEqual(new TimeSpan(24, 0, 0), c.CelestialInfo.DaySpan);
 
-            //No Rise
-            c = new Coordinate(76, 45, new DateTime(2021, 4, 24));
-            Assert.AreEqual(new TimeSpan(24, 0, 0), c.CelestialInfo.DaySpan + c.CelestialInfo.NightSpan);
-            Assert.AreEqual(c.CelestialInfo.SunSet.Value.TimeOfDay, c.CelestialInfo.DaySpan);
-
-            //Down all day
-            c = new Coordinate(-76, 45, new DateTime(2021, 2, 13));
+            //No Set
+            c = new Coordinate(66.771832, 22.339500, new DateTime(2024, 6, 2));
+            c.Offset = 2;
             Assert.AreEqual(new TimeSpan(24, 0, 0), c.CelestialInfo.DaySpan + c.CelestialInfo.NightSpan);
             Assert.AreEqual(c.CelestialInfo.SunRise.Value.TimeOfDay, c.CelestialInfo.NightSpan);
+
+            //No Rise
+            c = new Coordinate(78.2232, 15.6469, new DateTime(2024, 10, 26));
+            c.Offset = -11;
+            Assert.AreEqual(new TimeSpan(24, 0, 0), c.CelestialInfo.DaySpan + c.CelestialInfo.NightSpan);
+            Assert.AreEqual(c.CelestialInfo.SunSet.Value.TimeOfDay, c.CelestialInfo.DaySpan);
+        }
+        [TestMethod]
+        public void Check_Horizon_Hang_Correction()
+        {
+            EagerLoad el = new EagerLoad(EagerLoadType.Celestial);
+
+            //No Rise Reported, Correct to Up All Day
+            DateTime d = new DateTime(2021, 4, 24, 0, 0, 0);
+            var c = Celestial.CalculateCelestialTimes(76, 45, d, el, 0);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.UpAllDay);
+
+            //Next day is up all day, correct to No Set
+            d = new DateTime(2021, 4, 24, 0, 0, 0);
+            c = Celestial.CalculateCelestialTimes(76, 45, d, el, 3);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.NoSet);
+
+            //Ensure up all day
+            d = new DateTime(2021, 4, 25, 0, 0, 0);
+            c = Celestial.CalculateCelestialTimes(76, 45, d, el, 3);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.UpAllDay);
+      
+            //No set correct to up all day
+            d = new DateTime(2024, 6, 4);
+            c = Celestial.CalculateCelestialTimes(66.771832, 22.339500, d, el, 2);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.UpAllDay);
+
+            //No rise correct to up all day
+            d = new DateTime(2024, 7, 9);
+            c = Celestial.CalculateCelestialTimes(66.771832, 22.339500, d, el, 2);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.UpAllDay);
+
+            //Correct Up All Day
+            d = new DateTime(2024, 1, 8);
+            c = Celestial.CalculateCelestialTimes(-66.771832, 22.339500, d, el, 2);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.UpAllDay);
+
+            //Strip Set correction
+            d = new DateTime(2024, 12, 4);
+            c = Celestial.CalculateCelestialTimes(-66.771832, 22.339500, d, el, 2);
+            Assert.AreEqual(c.SunCondition, CelestialStatus.NoSet);
+
         }
     }
 

--- a/CoordinateSharp_UnitTests/GeoFence.cs
+++ b/CoordinateSharp_UnitTests/GeoFence.cs
@@ -151,10 +151,11 @@ namespace CoordinateSharp_UnitTests
 
             GeoFence ellipseTest = new GeoFence(points);
             GeoFence sphereTest = new GeoFence(new List<GeoFence.Point>(points));
+            GeoFence customTest = new GeoFence(new List<GeoFence.Point>(points));
 
-            
             ellipseTest.Densify(new Distance(5, DistanceType.Kilometers));        
             sphereTest.Densify(new Distance(5, DistanceType.Kilometers), Shape.Sphere);
+            customTest.Densify(new Distance(5, DistanceType.Kilometers), Earth_Ellipsoid.Get_Ellipsoid(Earth_Ellipsoid_Spec.WGS84_1984));
 
             string[] ellipseTestPoints = File.ReadAllText("GeoFenceData\\ColoradoEllipse.txt").Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             string[] sphereTestPoints = File.ReadAllText("GeoFenceData\\ColoradoSphere.txt").Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -166,6 +167,8 @@ namespace CoordinateSharp_UnitTests
                 double lng = double.Parse(point[1]);
                 Assert.AreEqual(ellipseTest.Points[x].Latitude, lat, .00000000001);
                 Assert.AreEqual(ellipseTest.Points[x].Longitude, lng, .00000000001);
+                Assert.AreEqual(customTest.Points[x].Latitude, lat, .00000000001);
+                Assert.AreEqual(customTest.Points[x].Longitude, lng, .00000000001);
             }
 
             for (int x = 0; x < sphereTestPoints.Length; x++)
@@ -176,6 +179,8 @@ namespace CoordinateSharp_UnitTests
                 Assert.AreEqual(sphereTest.Points[x].Latitude, lat, .00000000001);
                 Assert.AreEqual(sphereTest.Points[x].Longitude, lng, .00000000001);
             }
+
+           
         }
     
         /// <summary>


### PR DESCRIPTION
-Fixes bugs causing incorrect sun condition to report in circumpolar regions during slow transition at horizon. 

[Issue 167](https://github.com/Tronald/CoordinateSharp/issues/167)
[Issue 239](https://github.com/Tronald/CoordinateSharp/issues/239)

-Adds overload to `GeoFence.Denisfy()` to allow custom specification of earth shape during point densification.

[Issue 237](https://github.com/Tronald/CoordinateSharp/issues/237)