### PR TITLE
2.24.2.1

### DIFF
--- a/CoordinateSharp.Magnetic/CoordinateSharp.Magnetic.csproj
+++ b/CoordinateSharp.Magnetic/CoordinateSharp.Magnetic.csproj
@@ -47,7 +47,7 @@ For more information, please contact Signature Group, LLC at this address: sales
     <TargetFrameworks>net40; netstandard1.3; netstandard1.4; netstandard2.0; netstandard2.1; net50; net60; net70; net80</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.14.0</Version>
+    <Version>1.1.15.0</Version>
     <Authors>Signature Group, LLC</Authors>
     <Company />
     <PackageProjectUrl>https://github.com/Tronald/CoordinateSharp</PackageProjectUrl>
@@ -61,7 +61,7 @@ For more information, please contact Signature Group, LLC at this address: sales
     <PackageIconUrl></PackageIconUrl>
     <PackageId>CoordinateSharp.Magnetic</PackageId>
     <Title>CoordinateSharp.Magnetic</Title>
-    <AssemblyVersion>1.1.14.0</AssemblyVersion>
+    <AssemblyVersion>1.1.15.0</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>true</SignAssembly>
     <PackageIcon>128x128.png</PackageIcon>

--- a/CoordinateSharp/Celestial/Solar/SunCalculations.cs
+++ b/CoordinateSharp/Celestial/Solar/SunCalculations.cs
@@ -91,7 +91,12 @@ namespace CoordinateSharp
                     //https://github.com/Tronald/CoordinateSharp/issues/167
 
                     var safety = new Celestial();
-                    CalculateSunAngle(c.solarNoon.Value, lng, lat, safety, celC); 
+                    //Solarnoon may return null on certain days due to formula limitations in circumpolar regions.
+                    //When this occurs set noon to 00:00 because issue occurs around 0 hour.
+                    //The check is accurate enough for up or down all day determination
+                    DateTime? snoon = c.solarNoon;
+                    if (snoon == null) { snoon=actualDate.AddHours(-offset); }
+                    CalculateSunAngle(snoon.Value, lng, lat, safety, celC); 
                    
                     if (safety.sunAltitude <= -.8333)
                     {

--- a/CoordinateSharp/CoordinateSharp.csproj
+++ b/CoordinateSharp/CoordinateSharp.csproj
@@ -50,27 +50,28 @@ Please visit http://coordinatesharp.com/licensing or contact Signature Group, LL
     <TargetFrameworks>net40; netstandard1.3; netstandard1.4; netstandard2.0; netstandard2.1; net50; net60; net70; net80</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.24.1.1</Version>
+    <Version>2.24.2.1</Version>
     <Authors>Signature Group, LLC</Authors>
     <Company />
     <PackageProjectUrl>https://github.com/Tronald/CoordinateSharp</PackageProjectUrl>
     <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>Copyright 2024</Copyright>
     <Description>CoordinateSharp is a high powered, lightweight .NET library that can convert geographical coordinates, perform distance logic, and calculate location based sun, moon, and magnetic information with minimal code.</Description>
-    <PackageReleaseNotes>-Fixes bug causing incorrect sun condition to report in circumpolar regions during slow transition at horizon.
--Adds feature to allow custom specification of earth shape during point densification.</PackageReleaseNotes>
+    <PackageReleaseNotes>-Fixes critical bug causing exceptions near poles.
+-Fixes bugs causing incorrect sun condition to report in circumpolar regions during slow transition at horizon.
+-Adds overload to GeoFence.Denisfy() to allow custom specification of earth shape during point densification.</PackageReleaseNotes>
     <PackageTags>Conversion; Latitude; Longitude; Coordinates; Geography; Sun; Moon; Solar; Lunar; Time; MGRS; UTM; EPSG:3857; ECEF; GEOREF; Web Mercator;</PackageTags>
     <!-- <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>-->
     <PackageLicenseFile>License.txt</PackageLicenseFile>    <PackageIconUrl></PackageIconUrl>
     <PackageId>CoordinateSharp</PackageId>
     <Title>CoordinateSharp</Title>
-    <AssemblyVersion>2.24.1.1</AssemblyVersion>
+    <AssemblyVersion>2.24.2.1</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>true</SignAssembly>
     <PackageIcon>128x128.png</PackageIcon>
     <AssemblyOriginatorKeyFile>CoordinateSharp Strong Name.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <FileVersion>2.24.1.1</FileVersion>
+    <FileVersion>2.24.2.1</FileVersion>
     <RepositoryUrl>https://github.com/Tronald/CoordinateSharp</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/CoordinateSharp_UnitTests/Celestial.Solar.cs
+++ b/CoordinateSharp_UnitTests/Celestial.Solar.cs
@@ -13,6 +13,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace CoordinateSharp_UnitTests
 {
@@ -778,6 +779,7 @@ namespace CoordinateSharp_UnitTests
             Assert.AreEqual(c.SunCondition, CelestialStatus.NoSet);
 
         }
+       
     }
 
 

--- a/CoordinateSharp_UnitTests/Coordinate_Initialization_Tests.cs
+++ b/CoordinateSharp_UnitTests/Coordinate_Initialization_Tests.cs
@@ -3,6 +3,8 @@ using System;
 using CoordinateSharp;
 using NuGet.Frameworks;
 using System.Xml;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace CoordinateSharp_UnitTests
 {
@@ -53,6 +55,44 @@ namespace CoordinateSharp_UnitTests
             cp = new CoordinatePart(25, 25, 25, CoordinatesPosition.S);
             cp = new CoordinatePart(25, 25, 25, CoordinatesPosition.W);
 
+        }
+
+        //Test has high chance to catch random exception issues in circumpolar region.
+        //Long running however, so comment out until final tests ran if needed
+        [TestMethod]
+        public void CoordinateInitExceptionCheckNPole()
+        {
+            List<Task> tasks = new List<Task>();
+
+            for (int i1 = -180; i1 < 180; i1++)
+            {
+                DateTime dateTime1 = new DateTime(2024, 1, 1);
+
+                for (int i = 0; i < 365; i++)
+                {
+                    int currentI1 = i1;
+                    DateTime currentDate = dateTime1.AddDays(i);
+
+                    // Initialize the Coordinate object within a Task
+                    Task coordinateTask = Task.Run(() =>
+                    {                      
+                        var coordinate = new Coordinate(90, currentI1, currentDate);
+                        coordinate.Offset = 2;
+                        return coordinate;
+                    });
+
+                    tasks.Add(coordinateTask);
+                }
+            }
+
+            try
+            {
+                Task.WhenAll(tasks).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Task threw an exception: {ex}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
2.24.2.1
-Fixes critical bug causing exceptions near poles. 

2.24.1.1
-Fixes bugs causing incorrect sun condition to report in circumpolar regions during slow transition at horizon. 
-Adds overload to `GeoFence.Denisfy()` to allow custom specification of earth shape during point densification.